### PR TITLE
Update target framework to .NET 6 and GitExtensions.Extensibility dep to 0.3.2

### DIFF
--- a/src/GitExtensions.BranchNameCommitHintPlugin/GitExtensions.BranchNameCommitHintPlugin.csproj
+++ b/src/GitExtensions.BranchNameCommitHintPlugin/GitExtensions.BranchNameCommitHintPlugin.csproj
@@ -1,7 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFramework>net6-windows</TargetFramework>
+    <UseWindowsForms>true</UseWindowsForms>
     <VersionPrefix>1.1.2</VersionPrefix>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
   </PropertyGroup>
@@ -18,13 +19,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="GitExtensions.Extensibility" Version="0.3.0.57" />
+    <PackageReference Include="GitExtensions.Extensibility" Version="0.3.2.*" />
   </ItemGroup>
 
   <!--SourceLink support: https://github.com/dotnet/sourcelink -->
   <ItemGroup>
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="System.Drawing.Common" Version="6.0.0" />
+    <!--<PackageReference Include="System.Drawing.Common" Version="6.0.0" />-->
+    <PackageReference Include="System.ComponentModel.Composition" Version="6.0.0" />
     <!--<PackageReference Include="Microsoft.SourceLink.AzureRepos.Git" Version="1.0.0" PrivateAssets="All"/>-->
     <!--<PackageReference Include="Microsoft.SourceLink.AzureDevOpsServer.Git" Version="1.0.0" PrivateAssets="All"/>-->
     <!--<PackageReference Include="Microsoft.SourceLink.GitLab" Version="1.0.0" PrivateAssets="All"/>-->
@@ -39,8 +41,8 @@
     <Reference Include="ResourceManager">
       <HintPath>$(GitExtensionsPath)\ResourceManager.dll</HintPath>
     </Reference>
-    <Reference Include="System.ComponentModel.Composition" />
-    <Reference Include="System.Windows.Forms" />
+    <!--<Reference Include="System.ComponentModel.Composition" />-->
+    <!--<Reference Include="System.Windows.Forms" />-->
   </ItemGroup>
 
   <!-- Pack as .nupkg with dependency on GitExtensions.Extensibility -->


### PR DESCRIPTION
Update target framework to .NET 6 (same as current GitExtensions) and `GitExtensions.Extensibility` dependency to 0.3.2 to fix issue #1

Also drop now unnecessary assembly and package refs.

Note that a simple recompile with the new version of `GitExtensions.Extensibility` was enough b/c the breaking change (introduced optional param) is source-code compat. See https://github.com/gitextensions/gitextensions/commit/3d669363e49a74f4064b769e59fd1cf97706baee#diff-ba009d171028145f7f374231b8d7be6873df18b903fed275baa1bb2854f8b328.